### PR TITLE
Smarter Follow Link

### DIFF
--- a/const.ts
+++ b/const.ts
@@ -198,12 +198,18 @@ export const OTHER_COMMANDS: {
 		name: "Smarter Copy File Name",
 	},
 	{
+		id: "smarter-follow-link",
+		name: "Smarter Follow Link",
+	},
+	{
 		id: "hide-notice",
 		name: "Hide all Notices",
 	}
 ];
 
 export const URL_REGEX = /^((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()[\]{};:'".,<>?«»“”‘’]))$/i;
+
+export const LINK_REGEX = /\[[^[]+\]\((.*?)\)|\[\[(.*?)\|.*?\]\]|\[\[(.*?)\]\]/g;
 
 export const TRIMBEFORE = [
 	"\"",

--- a/const.ts
+++ b/const.ts
@@ -209,7 +209,11 @@ export const OTHER_COMMANDS: {
 
 export const URL_REGEX = /^((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()[\]{};:'".,<>?«»“”‘’]))$/i;
 
-export const LINK_REGEX = /\[[^[]+\]\((.*?)\)|\[\[(.*?)\|.*?\]\]|\[\[(.*?)\]\]/g;
+// RegEx to parse out any of the following:
+// * direct links, e.g. https://obsidian.md
+// * markdown links, e.g. [Link](https://example.com)
+// * (aliased) internal links, e.g. [[Internal Link]] or [[Internal Link|aliased]]
+export const LINK_REGEX = /(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))|(?:\[[^[]+\]\((.*?)\))|(?:\[\[(.*?)(?:\|.*?)?\]\])/g;
 
 export const TRIMBEFORE = [
 	"\"",

--- a/main.ts
+++ b/main.ts
@@ -127,12 +127,12 @@ export default class SmarterMDhotkeys extends Plugin {
 					// Follow link if there is only a single link in the given line
 					const [link] = links;
 					const [
-						/* linkMarkdown */,
-						externalLink,
-						regularInternalLink,
-						aliasedInternalLink
+						/* fullMatch */,
+						directURL,
+						markdownLink,
+						internalLink
 					] = link || [];
-					const internalLink = regularInternalLink || aliasedInternalLink;
+					const externalLink = markdownLink || directURL;
 
 					if (internalLink)
 						this.app.workspace.openLinkText(internalLink, activeFile.path);
@@ -144,15 +144,15 @@ export default class SmarterMDhotkeys extends Plugin {
 				default: {
 					for (const link of links) {
 						const [
-							linkMarkdown,
-							externalLink,
-							regularInternalLink,
-							aliasedInternalLink
+							fullMatch,
+							directURL,
+							markdownLink,
+							internalLink
 						] = link || [];
-						const internalLink = regularInternalLink || aliasedInternalLink;
+						const externalLink = markdownLink || directURL;
 
 						const isCursorOnMarkup =
-							cursor.ch >= link.index && cursor.ch <= link.index + linkMarkdown.length;
+							cursor.ch >= link.index && cursor.ch <= link.index + fullMatch.length;
 
 						// Open all external links when visually selected
 						if (selection && externalLink)


### PR DESCRIPTION
## Description of the Change
These changes add a new "Smarter Follow Link" command as referenced in #37 that has the following behaviors:
* Follow the link when the cursor is on any part of some URL
* Follow the link when the cursor is on any part of an internal link markup
* Follow the link when the cursor is on any part of an external link markup
* Follow the link when the cursor is on any part of a line when there it contains a single link
* ~Follow the closest link to wherever the cursor is when there is more than one link on the given line~
* Follow all external links that are visually selected

Note: I did have to modify the `OTHER_COMMANDS` add command loop to use `editorCallback` since this command is an "other command" but requires the `editor` API.

I also opted to not have the closest link functionality since it may be an unexpected/unintuitive behavior.

## Checklist
- [x] Used the provided eslint configuration, [as explained in the Readme](README.md#Contribute).
- [x] Did *not* use prettier.
- [x] Used expressive variable names.
- [x] Code is commented well.
